### PR TITLE
Remove unused 'chunksize' to keep gcc-4.6 happy

### DIFF
--- a/ngx_http_gridfs_module.c
+++ b/ngx_http_gridfs_module.c
@@ -681,7 +681,6 @@ static ngx_int_t ngx_http_gridfs_handler(ngx_http_request_t* request) {
     gridfs gfs;
     gridfile gfile;
     gridfs_offset length;
-    ngx_uint_t chunksize;
     ngx_uint_t numchunks;
     char* contenttype;
     volatile ngx_uint_t i;
@@ -814,7 +813,6 @@ static ngx_int_t ngx_http_gridfs_handler(ngx_http_request_t* request) {
 
     /* Get information about the file */
     length = gridfile_get_contentlength(&gfile);
-    chunksize = gridfile_get_chunksize(&gfile);
     numchunks = gridfile_get_numchunks(&gfile);
     contenttype = (char*)gridfile_get_contenttype(&gfile);
 


### PR DESCRIPTION
GCC 4.6 complains about chunksize being initialized and set but never used:

```
/opt/nginx-gridfs/ngx_http_gridfs_module.c:684:16: error: variable ‘chunksize’ set but not used [-Werror=unused-but-set-variable]
```
