### PR TITLE
Move grid file retrieval code up into (retried) init code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,10 @@
+Unmaintained
+============
+Note this is an unmaintained fork of Mike's original (also unmaintained) repo.
+I've done /some/ work on it - namely solving the problem of stale sockets if mongodb restarts, as well as integrating some other pull requests that weren't in the original -
+but last time I tried this module wouldn't compile against latest version of nginx (1.5.7).
+I've since abandoned this approach, in favour of the node server here: https://github.com/rdkls/node-gridfs-http-frontend so won't be spending any more time trying to get it working. It's not far off though ...
+
 nginx-gridfs
 ============
 :Authors:


### PR DESCRIPTION
It the mongo server restarts after nginx has started, nginx-gridfs then has a stale socket.
This wasn't getting picked up in the handler's initial code to check connection, and would fail later at "gridfs_find_query" time, returning 404.

This commit moves the "gridfs_find_query" call into the handler's initial gridfs_init loop, which is retried (by default) once if it initially fails.
The result is that if the mongo server restarts, nginx no longer has to be restarted to clear the stale handler; the failure of the find request triggers the "ngx_http_mongo_reconnect" call, then the subsequent call is successful (unless there actually is something wrong)
